### PR TITLE
Change grid to regularly-spaced

### DIFF
--- a/simulations/seamount.jl
+++ b/simulations/seamount.jl
@@ -174,25 +174,11 @@ end
 #+++ Base grid
 params = (; params..., factor)
 
-refinement = 1.1 # controls spacing near surface (higher means finer spaced)
-stretching = 25 # controls rate of stretching at bottom
-
-h₁(k) = ((-k + params.Nz) + 1) / params.Nz
-
-# Linear near-surface generator
-ζ₁(k) = 1 + (h₁(k) - 1) / refinement
-
-# Bottom-intensified stretching function 
-Σ₁(k) = (1 - exp(-stretching * h₁(k))) / (1 - exp(-stretching))
-
-# Generating function
-z_faces(k) = -params.Lz * (ζ₁(k) * Σ₁(k) - 1)
-
 grid_base = RectilinearGrid(arch, topology = (Periodic, Bounded, Bounded),
                             size = (params.Nx, params.Ny, params.Nz),
                             x = (-params.Lx/2, +params.Lx/2),
-                            y = (-params.y_offset, params.Ly-params.y_offset),
-                            z = z_faces,
+                            y = (-params.y_offset, params.Ly - params.y_offset),
+                            z = (0, params.Lz),
                             halo = (4,4,4),
                             )
 @info grid_base


### PR DESCRIPTION
With the currently geometry I can only do a very modest level of stretching, to the point that we don't gain much resolution. Since the pressure solver for a regular grid is faster, we end up slowing down the simulations a bit with stretching, so it doesn't make much sense to stretch.

Thus, this PR get rid of grid stretching and uses a regular grid.