### PR TITLE
Improve 3D plotting

### DIFF
--- a/simulations/plot_3d_animation.jl
+++ b/simulations/plot_3d_animation.jl
@@ -95,13 +95,14 @@ Colorbar(fig, vol3, bbox=ax3.scene.viewport,
          alignmode = Outside(10), halign = 0.85, valign = 1.02)
 #---
 
-# Save a snapshot as png
-save("$(@__DIR__)/../figures/seamount_3d_PV_snapshot.png", fig, px_per_unit=2)
 
 # Create title with time and parameters
 title = @lift "Roₕ = $(params.Ro_h), Frₕ = $(params.Fr_h), L = $(params.L) m, dz = $(params.dz) m;    " *
               "Time = $(@sprintf "%s" prettytime(times[$n]))"
 fig[0, 1:3] = Label(fig, title, fontsize=18, tellwidth=false, height=8)
+
+# Save a snapshot as png
+save("$(@__DIR__)/../figures/seamount_3d_PV_snapshot.png", fig, px_per_unit=2)
 
 # Record animation
 @info "Recording animation with $(length(times)) frames"


### PR DESCRIPTION
This PR improves the 3D plotting in general, but specifically it also starts plotting the dissipation rate. The main motivation here is that it's been hard for me to make sense of this very 3D simulation using just snapshots. So this helps create a mode complete understanding of where things are happening.