### PR TITLE
Try spectral filtering

### DIFF
--- a/bathymetry/spectral_filter.py
+++ b/bathymetry/spectral_filter.py
@@ -119,7 +119,7 @@ def butterworth_filter_2d(data, cutoff_wavelength, x_coord, y_coord, order=2):
 
 # Read the bathymetry data
 print("Reading bathymetry data...")
-ds = xr.open_dataset("balanus-bathymetry-preprocessed.nc")
+ds = xr.open_dataset("balanus-GMRT-bathymetry-preprocessed.nc")
 
 # Extract variables as DataArrays (keep xarray structure)
 elevation_da = ds["periodic_elevation"]


### PR DESCRIPTION
My previous attempt at spectral filtering didn't work because I was trying to do it after regriding the bathymetry into an Oceananigans grid, which was a bad idea. Trying to do it again with the full bathymetry produces better results, although still not as good as I had hoped:

<img width="1727" height="1026" alt="image" src="https://github.com/user-attachments/assets/dc43d9e6-1a45-49ca-bc65-0f8e0b998f0a" />

So maybe for now I'll keep the filtering procedure I have, but I'll keep this in the back pocket if I think it's worth switching.