### PR TITLE
Add postprocessing to CI test suite

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,8 +67,17 @@ jobs:
       - name: Install Julia packages
         run: julia --project=. -e 'import Pkg; Pkg.instantiate()'
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python packages
+        run: |
+          pip install xarray "dask[array]" numpy scipy cycler colorama netcdf4
+          pip install git+https://github.com/tomchor/pynanigans
+
       - name: Create output directories
-        run: mkdir -p simulations/data anims figures
+        run: mkdir -p simulations/data anims figures postprocessing/data
 
       - name: Run simulation
         env:
@@ -83,6 +92,11 @@ jobs:
           # requires OpenGL unavailable in CI. The verify step below checks that
           # the simulation itself and the 2D animation actually completed.
 
+      - name: Run postprocessing
+        run: |
+          cd postprocessing
+          python 00_postproc_ci.py
+
       - name: Verify outputs
         id: verify
         run: |
@@ -92,6 +106,9 @@ jobs:
           test -f simulations/data/aaai.ci_test.nc || { echo "FAIL: aaai output missing"; exit 1; }
           echo "=== Checking 2D animation ==="
           test -f anims/ci_test.mp4               || { echo "FAIL: 2D animation missing"; exit 1; }
+          echo "=== Checking postprocessing outputs ==="
+          test -f postprocessing/data/aaaa.ci_test.nc || { echo "FAIL: aaaa postprocessing output missing"; exit 1; }
+          test -f postprocessing/data/xyza.ci_test.nc || { echo "FAIL: xyza postprocessing output missing"; exit 1; }
           echo "=== All checks passed! ==="
 
       - name: Upload animation artifact

--- a/postprocessing/00_postproc_ci.py
+++ b/postprocessing/00_postproc_ci.py
@@ -1,0 +1,13 @@
+import sys
+sys.path.append("/glade/u/home/tomasc/repos/pynanigans") # Add pynanigans to PYTHONPATH (HPC path; pip-installed in CI)
+
+print("Starting CI post-processing")
+
+#+++ Define run options
+simdata_path = "../simulations/data/"
+simname_base = "ci_test"
+runs = [{}]  # single run, no parameter suffix
+#---
+
+exec(open("01_create_aaaa.py").read())
+exec(open("02_create_xyza.py").read())

--- a/postprocessing/01_create_aaaa.py
+++ b/postprocessing/01_create_aaaa.py
@@ -32,7 +32,8 @@ if not basename(__file__).startswith("00_postproc_"):
 #---
 
 for j, config in enumerate(runs):
-    simname = f"{simname_base}_" + aggregate_parameters(config, sep="_", prefix="")
+    suffix = aggregate_parameters(config, sep="_", prefix="")
+    simname = f"{simname_base}_{suffix}" if suffix else simname_base
 
     #+++ Open aaai dataset
     print(f"\nOpening {simname} aaai")

--- a/postprocessing/02_create_xyza.py
+++ b/postprocessing/02_create_xyza.py
@@ -40,7 +40,8 @@ indices = [1, 2, 3]
 
 
 for j, config in enumerate(runs):
-    simname = f"{simname_base}_" + aggregate_parameters(config, sep="_", prefix="")
+    suffix = aggregate_parameters(config, sep="_", prefix="")
+    simname = f"{simname_base}_{suffix}" if suffix else simname_base
 
     #+++ Open dataset
     print(f"\nOpening {simname} xyzi")


### PR DESCRIPTION
## Summary

- Adds Python + pynanigans setup to the CI workflow
- New `postprocessing/00_postproc_ci.py` driver runs `01_create_aaaa.py` and `02_create_xyza.py` against the `ci_test` simulation output
- Verifies `aaaa.ci_test.nc` and `xyza.ci_test.nc` are produced in addition to the existing simulation checks
- Fixes a minor simname construction bug in `01_create_aaaa.py` and `02_create_xyza.py`: an empty parameter suffix no longer produces a trailing underscore (e.g. `"ci_test_"` → `"ci_test"`)

## Test plan

- [ ] Trigger with `/run-tests` on this PR and confirm all verify checks pass
- [ ] Confirm `aaaa.ci_test.nc` and `xyza.ci_test.nc` are present in the verify step output

🤖 Generated with [Claude Code](https://claude.com/claude-code)